### PR TITLE
Convert dataflow code model to a single compiled bundle

### DIFF
--- a/tasks/build.rs
+++ b/tasks/build.rs
@@ -33,6 +33,8 @@ fn build_snapshots() {
 }
 
 fn build_js_helpers() {
+    println!("cargo:rerun-if-changed=js_helpers/src");
+    println!("cargo:rerun-if-changed=js_helpers/rollup.config.js");
     println!("cargo:rerun-if-changed=scripting/js_helpers");
 
     let input_glob = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/tasks/build.rs
+++ b/tasks/build.rs
@@ -33,8 +33,9 @@ fn build_snapshots() {
 }
 
 fn build_js_helpers() {
-    println!("cargo:rerun-if-changed=js_helpers/src");
-    println!("cargo:rerun-if-changed=js_helpers/rollup.config.js");
+    println!("cargo:rerun-if-changed=js_helpers");
+    println!("cargo:rerun-if-changed=js_helpers");
+    println!("cargo:rerun-if-changed=js_helpers");
     println!("cargo:rerun-if-changed=scripting/js_helpers");
 
     let input_glob = PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/tasks/dataflow/dag.rs
+++ b/tasks/dataflow/dag.rs
@@ -143,11 +143,7 @@ mod tests {
     }
 
     fn test_edge(from: u32, to: u32) -> DataFlowEdge {
-        DataFlowEdge {
-            from,
-            to,
-            name: String::new(),
-        }
+        DataFlowEdge { from, to }
     }
 
     mod toposort {
@@ -268,6 +264,8 @@ mod tests {
             DataFlowConfig {
                 nodes: (0..7).map(|_| blank_node()).collect(),
                 edges,
+                compiled: String::new(),
+                map: None,
                 toposorted,
             }
         }

--- a/tasks/dataflow/node.rs
+++ b/tasks/dataflow/node.rs
@@ -148,7 +148,15 @@ impl DataFlowNodeFunction {
                     console: Vec::new(),
                 }))
             }
-            Self::Text(_) | Self::Table | Self::Graph => Ok(None),
+            Self::Text(t) => {
+                let state = runner.set_node_state(node_name, &json!(t.body)).await?;
+                Ok(Some(NodeResult {
+                    state,
+                    action: None,
+                    console: Vec::new(),
+                }))
+            }
+            Self::Table | Self::Graph => Ok(None),
         }
     }
 

--- a/tasks/dataflow/node.rs
+++ b/tasks/dataflow/node.rs
@@ -1,14 +1,17 @@
+use std::borrow::Cow;
+
 use crate::{actions::TaskActionInvocation, Error, Result};
+pub use ergo_js::ConsoleMessage;
 use fxhash::FxHashMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-pub use js::ConsoleMessage;
+use super::run::DataFlowRunner;
 
 #[derive(Debug)]
 pub(crate) struct NodeResult {
-    pub state: serde_json::Value,
+    pub state: String,
     pub action: Option<TaskActionInvocation>,
     pub console: Vec<ConsoleMessage>,
 }
@@ -16,15 +19,15 @@ pub(crate) struct NodeResult {
 impl NodeResult {
     pub fn empty() -> Self {
         Self {
-            state: serde_json::Value::Null,
+            state: String::new(),
             action: None,
             console: Vec::new(),
         }
     }
 }
 
-impl From<(serde_json::Value, Vec<ConsoleMessage>)> for NodeResult {
-    fn from((state, console): (serde_json::Value, Vec<ConsoleMessage>)) -> Self {
+impl From<(String, Vec<ConsoleMessage>)> for NodeResult {
+    fn from((state, console): (String, Vec<ConsoleMessage>)) -> Self {
         Self {
             state,
             action: None,
@@ -112,8 +115,8 @@ pub enum JsCodeFormat {
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct DataFlowJs {
-    pub code: String,
-    pub format: JsCodeFormat,
+    /// The name of the function in the compiled code that stores this node.
+    pub func: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -122,57 +125,36 @@ pub struct DataFlowAction {
     pub payload_code: DataFlowJs,
 }
 
-pub(super) enum NodeInput {
-    Single(serde_json::Value),
-    Multiple(FxHashMap<String, serde_json::Value>),
-}
-
-impl From<NodeInput> for serde_json::Value {
-    fn from(input: NodeInput) -> Self {
-        match input {
-            NodeInput::Single(value) => value,
-            NodeInput::Multiple(map) => json!(map),
-        }
-    }
-}
-
 impl DataFlowNodeFunction {
     pub(super) async fn execute(
         &self,
         task_name: &str,
         node_name: &str,
-        current_state: &serde_json::Value,
-        input: NodeInput,
+        runner: &DataFlowRunner,
+        input: Option<serde_json::Value>,
     ) -> Result<NodeResult> {
         match self {
-            Self::Js(expr) => js::run_js(task_name, node_name, expr, current_state.clone(), input)
+            Self::Js(expr) => run_js(task_name, node_name, runner, expr)
                 .await
                 .map(NodeResult::from),
-            Self::Action(expr) => {
-                evaluate_action_node(task_name, node_name, expr, current_state.clone(), input).await
+            Self::Action(expr) => evaluate_action_node(task_name, node_name, runner, expr).await,
+            Self::Trigger(_) => {
+                let value = input.unwrap_or_default();
+                let store_state = runner.set_node_state(node_name, &value).await?;
+                Ok(NodeResult {
+                    state: store_state,
+                    action: None,
+                    console: Vec::new(),
+                })
             }
-            Self::Trigger(_) => Ok(NodeResult {
-                state: input.into(),
-                action: None,
-                console: Vec::new(),
-            }),
             Self::Text(_) | Self::Table | Self::Graph => Ok(NodeResult::empty()),
         }
     }
 
     pub(super) fn persist_output(&self) -> bool {
         match self {
-            Self::Js(_) | Self::Action(_) | Self::Trigger(_) => true,
-            Self::Table | Self::Graph | Self::Text(_) => false,
-        }
-    }
-
-    pub(super) fn output(&self, state: &serde_json::Value) -> serde_json::Value {
-        match self {
-            Self::Js(_) | Self::Action(_) | Self::Trigger(_) => state.clone(),
-            Self::Text(node) => json!(node.body),
-            // Self::JsCode(node) => json!(node.code()),
-            Self::Table | Self::Graph => serde_json::Value::Null,
+            Self::Js(_) | Self::Action(_) | Self::Trigger(_) | Self::Table | Self::Graph => true,
+            Self::Text(_) => false,
         }
     }
 }
@@ -180,30 +162,38 @@ impl DataFlowNodeFunction {
 async fn evaluate_action_node(
     task_name: &str,
     node_name: &str,
+    runner: &DataFlowRunner,
     action: &DataFlowAction,
-    current_state: serde_json::Value,
-    input: NodeInput,
 ) -> Result<NodeResult> {
-    let (result, console) = js::run_js(
-        task_name,
-        node_name,
-        &action.payload_code,
-        current_state,
-        input,
-    )
-    .await?;
+    let (result, console) = run_js(task_name, node_name, runner, &action.payload_code)
+        .await
+        .map_err(|e| match e {
+            Error::TaskScript { error, console } => Error::DataflowScript {
+                node: node_name.to_string(),
+                error,
+                console,
+            },
+            _ => e,
+        })?;
 
-    let action_payload = match &result {
+    let action_payload =
+        runner
+            .get_raw_state(node_name)
+            .await
+            .map_err(|e| Error::DataflowGetStateError {
+                node: node_name.to_string(),
+                error: e,
+            })?;
+
+    let action = match action_payload {
         serde_json::Value::Null => None,
-        serde_json::Value::Object(_) => Some(result.clone()),
+        serde_json::Value::Object(_) => Some(TaskActionInvocation {
+            name: action.action_id.clone(),
+            payload: action_payload,
+        }),
         // TODO Log an error here?
         _ => None,
     };
-
-    let action = action_payload.map(|payload| TaskActionInvocation {
-        name: action.action_id.clone(),
-        payload,
-    });
 
     Ok(NodeResult {
         state: result,
@@ -212,82 +202,14 @@ async fn evaluate_action_node(
     })
 }
 
-const ASYNC_FUNCTION_START: &str = r##"(async function() { "##;
-const SYNC_FUNCTION_START: &str = r##"(function() { "##;
-const FUNCTION_END: &str = r##" })()"##;
-
-fn wrap_code(expr: &DataFlowJs) -> String {
-    match expr.format {
-        JsCodeFormat::Expression => format!(
-            "{SYNC_FUNCTION_START}return {body}{FUNCTION_END}",
-            body = expr.code
-        ),
-        JsCodeFormat::Function => format!(
-            "{SYNC_FUNCTION_START}{body}{FUNCTION_END}",
-            body = expr.code
-        ),
-        JsCodeFormat::AsyncFunction => format!(
-            "{ASYNC_FUNCTION_START}{body}{FUNCTION_END}",
-            body = expr.code
-        ),
-    }
-}
-
-#[cfg(target_family = "wasm")]
-mod js {
-    use super::*;
-
-    #[derive(Debug, Deserialize, Serialize)]
-    pub struct ConsoleMessage {
-        level: i32,
-        message: String,
-    }
-
-    pub(super) async fn run_js(
-        task_name: &str,
-        node_name: &str,
-        expr: &DataFlowJs,
-        current_state: serde_json::Value,
-        input: NodeInput,
-    ) -> Result<(serde_json::Value, Vec<ConsoleMessage>)> {
-        let code = wrap_code(expr);
-        let result = js_sys::eval(&code)?;
-
-        Ok((serde_wasm_bindgen::from_value(result)?, Vec::new()))
-    }
-}
-
-#[cfg(not(target_family = "wasm"))]
-mod js {
-    use super::*;
-    use crate::scripting::{create_task_script_runtime, POOL};
-    pub use ergo_js::ConsoleMessage;
-    use ergo_js::Runtime;
-
-    pub(super) async fn run_js(
-        task_name: &str,
-        node_name: &str,
-        expr: &DataFlowJs,
-        current_state: serde_json::Value,
-        input: NodeInput,
-    ) -> Result<(serde_json::Value, Vec<ConsoleMessage>)> {
-        let name = format!("https://ergo/tasks/{task_name}/{node_name}.js");
-        let wrapped = wrap_code(expr);
-
-        POOL.run(move || async move {
-            let mut runtime = create_task_script_runtime(true);
-            set_up_env(&mut runtime, current_state, input).map_err(Error::TaskScriptSetup)?;
-
-            let run_result = runtime
-                .await_expression::<serde_json::Value>(&name, &wrapped)
-                .await;
-            let console = runtime.take_console_messages();
-            match run_result {
-                Ok(value) => Ok((value, console)),
-                // TODO Generate a source map and use it to translate the code locations in the error.
-                Err(error) => Err(Error::TaskScript { error, console }),
-            }
-        })
+async fn run_js(
+    task_name: &str,
+    node_name: &str,
+    runner: &DataFlowRunner,
+    expr: &DataFlowJs,
+) -> Result<(String, Vec<ConsoleMessage>)> {
+    runner
+        .run_node(task_name, node_name, &expr.func)
         .await
         .map_err(|e| match e {
             Error::TaskScript { error, console } => Error::DataflowScript {
@@ -297,24 +219,4 @@ mod js {
             },
             _ => e,
         })
-    }
-
-    fn set_up_env(
-        runtime: &mut Runtime,
-        current_state: serde_json::Value,
-        input: NodeInput,
-    ) -> Result<(), anyhow::Error> {
-        runtime.set_global_value("last_value", &current_state)?;
-
-        match input {
-            NodeInput::Single(value) => runtime.set_global_value("value", &value)?,
-            NodeInput::Multiple(values) => {
-                for (key, value) in values {
-                    runtime.set_global_value(&key, &value)?;
-                }
-            }
-        }
-
-        Ok(())
-    }
 }

--- a/tasks/dataflow/run.rs
+++ b/tasks/dataflow/run.rs
@@ -1,0 +1,123 @@
+use ergo_js::{worker::JsWorker, ConsoleMessage};
+use futures::FutureExt;
+use fxhash::FxHashMap;
+use serde::de::DeserializeOwned;
+
+use super::{DataFlowConfig, DataFlowState};
+use crate::{Error, Result};
+
+pub const DATAFLOW_ENV_CODE: &str = include_str!("../js_helpers/dist/dataflow.js");
+
+pub struct DataFlowRunner {
+    worker: ergo_js::worker::JsWorker,
+}
+
+impl DataFlowRunner {
+    pub async fn new(
+        config: &DataFlowConfig,
+        state: &DataFlowState,
+    ) -> Result<DataFlowRunner, Error> {
+        let state: FxHashMap<&str, &str> = config
+            .nodes
+            .iter()
+            .zip(state.nodes.iter())
+            .map(|(c, s)| (c.name.as_str(), s.as_str()))
+            .collect();
+
+        let state = serde_json::to_string(&state)?;
+        let code = format!("globalThis.__ergo_nodecode = {};", config.compiled);
+        let set_node_state = format!("__ergo_dataflow.initState({state})");
+
+        let worker = JsWorker::new();
+        worker
+            .run(|runtime| {
+                async move {
+                    runtime.execute_script("task_environment", DATAFLOW_ENV_CODE)?;
+                    runtime.execute_script("node_state", &set_node_state)?;
+                    runtime.execute_script("node_code", &code)?;
+                    Ok::<(), ergo_js::Error>(())
+                }
+                .boxed_local()
+            })
+            .await
+            .map_err(|e| Error::DataflowInitScriptError { error: e })?;
+
+        Ok(DataFlowRunner { worker })
+    }
+
+    /// Run a node and return the result, serialized for storage.
+    pub async fn run_node(
+        &self,
+        task_name: &str,
+        node_name: &str,
+        node_func: &str,
+    ) -> Result<(String, Vec<ConsoleMessage>), Error> {
+        let name = format!("https://ergo/tasks/{task_name}/{node_name}.js");
+        let func_call = format!(
+            r##"__ergo_dataflow.runNode("{node_name}", "__ergo_nodecode", "{node_func}")"##
+        );
+
+        self.worker
+            .run(move |runtime| {
+                async move {
+                    let run_result = runtime.await_expression::<String>(&name, &func_call).await;
+                    let console = runtime.take_console_messages();
+                    match run_result {
+                        Ok(value) => Ok((value, console)),
+                        // TODO Generate a source map and use it to translate the code locations in the error.
+                        Err(error) => Err(Error::TaskScript { error, console }),
+                    }
+                }
+                .boxed_local()
+            })
+            .await
+    }
+
+    /// Set a node's state and return the serialized version of the state.
+    pub async fn set_node_state(
+        &self,
+        node_name: &str,
+        value: &serde_json::Value,
+    ) -> Result<String> {
+        let json = serde_json::to_string(value)?;
+        let code = format!(r##"__ergo_dataflow.setNodeState("{node_name}", {json})"##);
+
+        self.worker
+            .run(move |runtime| {
+                async move { runtime.run_expression::<String>("set_node_state", &code) }
+                    .boxed_local()
+            })
+            .await
+            .map_err(|e| Error::DataflowSetStateError {
+                node: node_name.to_string(),
+                error: e,
+            })
+    }
+
+    pub async fn get_raw_state(
+        &self,
+        node_name: &str,
+    ) -> Result<serde_json::Value, ergo_js::Error> {
+        let code = format!(r##"__ergo_dataflow.getState("{node_name}")"##);
+        self.worker
+            .run(|runtime| {
+                async move { runtime.run_expression::<serde_json::Value>("get_state", &code) }
+                    .boxed_local()
+            })
+            .await
+    }
+
+    pub async fn retrieve_state(&self) -> Result<FxHashMap<String, String>, ergo_js::Error> {
+        self.worker
+            .run(|runtime| {
+                async move {
+                    runtime.run_expression::<FxHashMap<String, String>>(
+                        "retrieve_state",
+                        "__ergo_dataflow.serializeState()",
+                    )
+                }
+                .boxed_local()
+            })
+            .await
+    }
+}

--- a/tasks/dataflow/run.rs
+++ b/tasks/dataflow/run.rs
@@ -51,10 +51,17 @@ impl DataFlowRunner {
         task_name: &str,
         node_name: &str,
         node_func: &str,
+        null_check_nodes: &[&str],
     ) -> Result<(String, Vec<ConsoleMessage>), Error> {
         let name = format!("https://ergo/tasks/{task_name}/{node_name}.js");
+        let null_checks = if null_check_nodes.is_empty() {
+            "null".to_string()
+        } else {
+            serde_json::to_string(null_check_nodes)?
+        };
+
         let func_call = format!(
-            r##"__ergo_dataflow.runNode("{node_name}", "__ergo_nodecode", "{node_func}")"##
+            r##"__ergo_dataflow.runNode("{node_name}", "__ergo_nodecode", "{node_func}", {null_checks})"##
         );
 
         self.worker

--- a/tasks/error.rs
+++ b/tasks/error.rs
@@ -69,6 +69,12 @@ pub enum Error {
         console: Vec<ConsoleMessage>,
     },
 
+    #[error("Failed to initialize dataflow environment: {error}")]
+    DataflowInitScriptError {
+        #[source]
+        error: ergo_js::Error,
+    },
+
     #[error("Dataflow node {node} script error: {error}")]
     #[cfg(not(target_family = "wasm"))]
     DataflowScript {
@@ -76,6 +82,22 @@ pub enum Error {
         #[source]
         error: ergo_js::Error,
         console: Vec<ConsoleMessage>,
+    },
+
+    #[error("Failed to read result from node {node}: {error}")]
+    #[cfg(not(target_family = "wasm"))]
+    DataflowGetStateError {
+        node: String,
+        #[source]
+        error: ergo_js::Error,
+    },
+
+    #[error("Failed to write state for node {node}: {error}")]
+    #[cfg(not(target_family = "wasm"))]
+    DataflowSetStateError {
+        node: String,
+        #[source]
+        error: ergo_js::Error,
     },
 
     #[error("Parsing cron schedule: {0}")]

--- a/tasks/js_helpers/.gitignore
+++ b/tasks/js_helpers/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/tasks/js_helpers/package.json
+++ b/tasks/js_helpers/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "js_helpers",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "NODE_ENV=production rollup -c rollup.config.js",
+    "dev": "NODE_ENV=development rollup -c rollup.config.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "Apache-2.0/MIT",
+  "dependencies": {
+    "devalue": "~4.2.2"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "~15.0.1",
+    "@rollup/plugin-terser": "~0.3.0",
+    "rollup": "~3.10.1"
+  }
+}

--- a/tasks/js_helpers/pnpm-lock.yaml
+++ b/tasks/js_helpers/pnpm-lock.yaml
@@ -1,0 +1,252 @@
+lockfileVersion: 5.4
+
+specifiers:
+  '@rollup/plugin-node-resolve': ~15.0.1
+  '@rollup/plugin-terser': ~0.3.0
+  devalue: ~4.2.2
+  rollup: ~3.10.1
+
+dependencies:
+  devalue: 4.2.2
+
+devDependencies:
+  '@rollup/plugin-node-resolve': 15.0.1_rollup@3.10.1
+  '@rollup/plugin-terser': 0.3.0_rollup@3.10.1
+  rollup: 3.10.1
+
+packages:
+
+  /@jridgewell/gen-mapping/0.3.2:
+    resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/trace-mapping': 0.3.17
+    dev: true
+
+  /@jridgewell/resolve-uri/3.1.0:
+    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/set-array/1.1.2:
+    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/source-map/0.3.2:
+    resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.17
+    dev: true
+
+  /@jridgewell/sourcemap-codec/1.4.14:
+    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.17:
+    resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.0
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
+
+  /@rollup/plugin-node-resolve/15.0.1_rollup@3.10.1:
+    resolution: {integrity: sha512-ReY88T7JhJjeRVbfCyNj+NXAG3IIsVMsX9b5/9jC98dRP8/yxlZdz7mHZbHk5zHr24wZZICS5AcXsFZAXYUQEg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@rollup/pluginutils': 5.0.2_rollup@3.10.1
+      '@types/resolve': 1.20.2
+      deepmerge: 4.2.2
+      is-builtin-module: 3.2.0
+      is-module: 1.0.0
+      resolve: 1.22.1
+      rollup: 3.10.1
+    dev: true
+
+  /@rollup/plugin-terser/0.3.0_rollup@3.10.1:
+    resolution: {integrity: sha512-mYTkNW9KjOscS/3QWU5LfOKsR3/fAAVDaqcAe2TZ7ng6pN46f+C7FOZbITuIW/neA+PhcjoKl7yMyB3XcmA4gw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.x || ^3.x
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      rollup: 3.10.1
+      serialize-javascript: 6.0.1
+      smob: 0.0.6
+      terser: 5.16.1
+    dev: true
+
+  /@rollup/pluginutils/5.0.2_rollup@3.10.1:
+    resolution: {integrity: sha512-pTd9rIsP92h+B6wWwFbW8RkZv4hiR/xKsqre4SIuAOaOEQRxi0lqLke9k2/7WegC85GgUs9pjmOjCUi3In4vwA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      '@types/estree': 1.0.0
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+      rollup: 3.10.1
+    dev: true
+
+  /@types/estree/1.0.0:
+    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
+    dev: true
+
+  /@types/resolve/1.20.2:
+    resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+    dev: true
+
+  /acorn/8.8.1:
+    resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /buffer-from/1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
+
+  /builtin-modules/3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
+    dev: true
+
+  /commander/2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    dev: true
+
+  /deepmerge/4.2.2:
+    resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /devalue/4.2.2:
+    resolution: {integrity: sha512-Pkwd8qrI9O20VJ14fBNHu+on99toTNZFbgWRpZbC0zbDXpnE2WHYcrC1fHhMsF/3Ee+2yaW7vEujAT7fCYgqrA==}
+    dev: false
+
+  /estree-walker/2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    dev: true
+
+  /fsevents/2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /function-bind/1.1.1:
+    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    dev: true
+
+  /has/1.0.3:
+    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
+    engines: {node: '>= 0.4.0'}
+    dependencies:
+      function-bind: 1.1.1
+    dev: true
+
+  /is-builtin-module/3.2.0:
+    resolution: {integrity: sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==}
+    engines: {node: '>=6'}
+    dependencies:
+      builtin-modules: 3.3.0
+    dev: true
+
+  /is-core-module/2.11.0:
+    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
+    dependencies:
+      has: 1.0.3
+    dev: true
+
+  /is-module/1.0.0:
+    resolution: {integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==}
+    dev: true
+
+  /path-parse/1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
+
+  /picomatch/2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+    dev: true
+
+  /randombytes/2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: true
+
+  /resolve/1.22.1:
+    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.11.0
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
+  /rollup/3.10.1:
+    resolution: {integrity: sha512-3Er+yel3bZbZX1g2kjVM+FW+RUWDxbG87fcqFM5/9HbPCTpbVp6JOLn7jlxnNlbu7s/N/uDA4EV/91E2gWnxzw==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
+  /safe-buffer/5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: true
+
+  /serialize-javascript/6.0.1:
+    resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
+    dependencies:
+      randombytes: 2.1.0
+    dev: true
+
+  /smob/0.0.6:
+    resolution: {integrity: sha512-V21+XeNni+tTyiST1MHsa84AQhT1aFZipzPpOFAVB8DkHzwJyjjAmt9bgwnuZiZWnIbMo2duE29wybxv/7HWUw==}
+    dev: true
+
+  /source-map-support/0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    dev: true
+
+  /source-map/0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /supports-preserve-symlinks-flag/1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+    dev: true
+
+  /terser/5.16.1:
+    resolution: {integrity: sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/source-map': 0.3.2
+      acorn: 8.8.1
+      commander: 2.20.3
+      source-map-support: 0.5.21
+    dev: true

--- a/tasks/js_helpers/rollup.config.js
+++ b/tasks/js_helpers/rollup.config.js
@@ -1,0 +1,11 @@
+import nodeResolve from '@rollup/plugin-node-resolve';
+import terser from '@rollup/plugin-terser';
+export default [
+  { input: 'src/dataflow.js',
+    output: { file: 'dist/dataflow.js', name: '__ergo_dataflow', format: 'iife' },
+    plugins: [
+      nodeResolve(),
+      process.env.NODE_ENV === 'production' && terser(),
+    ]
+  },
+]

--- a/tasks/js_helpers/src/dataflow.js
+++ b/tasks/js_helpers/src/dataflow.js
@@ -1,0 +1,36 @@
+import { stringify, parse } from 'devalue' ;
+
+let nodeState = {};
+
+export function initState(stateObj) {
+  nodeState = {}
+  for(let [id, value] of Object.entries(stateObj)) {
+    nodeState[id] = value ? parse(value) : null;
+  }
+}
+
+export function serializeState() {
+  let output = {};
+  for(let [id, value] of Object.entries(nodeState)) {
+    output[id] = stringify(value);
+  }
+  return output;
+}
+
+export function getState(nodeName) {
+  return nodeState[nodeName];
+}
+
+export function setNodeState(nodeName, state) {
+  let s = stringify(state);
+  nodeState[nodeName] = s;
+  return s;
+}
+
+export async function runNode(nodeName, nodeNamespace, nodeFunc) {
+  let nodeFn = globalThis[nodeNamespace][nodeFunc];
+
+  let state_result = await nodeFn(nodeState);
+  nodeState[nodeName] = state_result;
+  return stringify(state_result);
+}

--- a/tasks/js_helpers/src/dataflow.js
+++ b/tasks/js_helpers/src/dataflow.js
@@ -22,9 +22,8 @@ export function getState(nodeName) {
 }
 
 export function setNodeState(nodeName, state) {
-  let s = stringify(state);
-  nodeState[nodeName] = s;
-  return s;
+  nodeState[nodeName] = state;
+  return stringify(state);
 }
 
 export async function runNode(nodeName, nodeNamespace, nodeFunc, nullCheckNodes) {
@@ -32,6 +31,7 @@ export async function runNode(nodeName, nodeNamespace, nodeFunc, nullCheckNodes)
 
   if(Array.isArray(nullCheckNodes)) {
     for(let node of nullCheckNodes) {
+      // Skip on null or undefined. Empty string indicates that nothing happened.
       if(nodeState[node] == null) {
         return '';
       }

--- a/tasks/js_helpers/src/dataflow.js
+++ b/tasks/js_helpers/src/dataflow.js
@@ -27,8 +27,16 @@ export function setNodeState(nodeName, state) {
   return s;
 }
 
-export async function runNode(nodeName, nodeNamespace, nodeFunc) {
+export async function runNode(nodeName, nodeNamespace, nodeFunc, nullCheckNodes) {
   let nodeFn = globalThis[nodeNamespace][nodeFunc];
+
+  if(Array.isArray(nullCheckNodes)) {
+    for(let node of nullCheckNodes) {
+      if(nodeState[node] == null) {
+        return '';
+      }
+    }
+  }
 
   let state_result = await nodeFn(nodeState);
   nodeState[nodeName] = state_result;

--- a/tasks/js_helpers/src/dataflow.js
+++ b/tasks/js_helpers/src/dataflow.js
@@ -40,5 +40,5 @@ export async function runNode(nodeName, nodeNamespace, nodeFunc, nullCheckNodes)
 
   let state_result = await nodeFn(nodeState);
   nodeState[nodeName] = state_result;
-  return stringify(state_result);
+  return stringify(state_result ?? null);
 }


### PR DESCRIPTION
This makes it much easier to reuse code and state between different nodes, and allows more use of JS for the state management which will help with running things on the frontend. It will also set the stage for integrating code libraries into the bundle.

Also added a check for which nodes should actually be run based on if an upstream node had run -- previously we would just start at the triggered node and run everything after it in the toposorted list.